### PR TITLE
added `ray.init(); ray.shutdown()`

### DIFF
--- a/projects/ray/test.py
+++ b/projects/ray/test.py
@@ -1,1 +1,3 @@
 import ray
+ray.init()
+ray.shutdown()


### PR DESCRIPTION
We need some way get the redis-server up and running, and a call to `ray.init()` in the test would alert us when it didn't work. (Ray can't be used without calling `ray.init()`. 

error when I do `import ray; ray.init()` in a `nix-shell` version of python39 with this installation of `ray`: 
```sh
[2021-10-07 20:35:48,646 C 74206 74206] service_based_gcs_client.cc:72:  Check failed: GetGcsServerAddress
FromRedis( redis_client_->GetPrimaryContext()->sync_context(), &current_gcs_server_address_, RayConfig::in
stance().gcs_service_connect_retries()) Failed to get gcs server address when init gcs client.           
*** StackTrace Information ***
    ray::SpdLogMessage::Flush()
    ray::RayLog::~RayLog()
    ray::gcs::ServiceBasedGcsClient::Connect()
    ray::gcs::GlobalStateAccessor::Connect()
    __pyx_pw_3ray_7_raylet_19GlobalStateAccessor_3connect()
    method_vectorcall_NOARGS
```

Error when I put `python -c "import ray; ray.init(); ray.shutdown()"` in `buildPhase` of a `default.nix` and run `nix-build`: 
```sh
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/nix/store/0f1rswm8xm1vg7safmgybhv95762wlpf-ray-1.6.0-python39-out/lib/python3.9/site-packages/ray
/_private/client_mode_hook.py", line 82, in wrapper                                                      
    return func(*args, **kwargs)
  File "/nix/store/0f1rswm8xm1vg7safmgybhv95762wlpf-ray-1.6.0-python39-out/lib/python3.9/site-packages/ray
/worker.py", line 892, in init                                                                           
    _global_node = ray.node.Node(
  File "/nix/store/0f1rswm8xm1vg7safmgybhv95762wlpf-ray-1.6.0-python39-out/lib/python3.9/site-packages/ray
/node.py", line 248, in __init__                                                                         
    self.start_head_processes()
  File "/nix/store/0f1rswm8xm1vg7safmgybhv95762wlpf-ray-1.6.0-python39-out/lib/python3.9/site-packages/ray
/node.py", line 894, in start_head_processes                                                             
    self.start_redis()
  File "/nix/store/0f1rswm8xm1vg7safmgybhv95762wlpf-ray-1.6.0-python39-out/lib/python3.9/site-packages/ray
/node.py", line 702, in start_redis                                                                      
    process_infos) = ray._private.services.start_redis(
  File "/nix/store/0f1rswm8xm1vg7safmgybhv95762wlpf-ray-1.6.0-python39-out/lib/python3.9/site-packages/ray
/_private/services.py", line 869, in start_redis                                                         
    port, p = _start_redis_instance(
  File "/nix/store/0f1rswm8xm1vg7safmgybhv95762wlpf-ray-1.6.0-python39-out/lib/python3.9/site-packages/ray
/_private/services.py", line 1005, in _start_redis_instance                                              
    process_info = start_ray_process(
  File "/nix/store/0f1rswm8xm1vg7safmgybhv95762wlpf-ray-1.6.0-python39-out/lib/python3.9/site-packages/ray
/_private/services.py", line 593, in start_ray_process                                                   
    process = ConsolePopen(
  File "/nix/store/dqxic3j7csd4ywn94n4smmnz55p039g3-python3-3.9.6/lib/python3.9/subprocess.py", line 951, 
in __init__                                                                                              
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/nix/store/dqxic3j7csd4ywn94n4smmnz55p039g3-python3-3.9.6/lib/python3.9/subprocess.py", line 1821,
 in _execute_child                                                                                       
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/0f1rswm8xm1vg7safmgybhv95762wlpf-ray-1
.6.0-python39-out/lib/python3.9/site-packages/ray/core/src/ray/thirdparty/redis/src/redis-server'
```

Let me know if you can think of a way for me to get the ray build offered by your project up to speed, if you don't have time to do it! I checked `discuss.ray.io` for `Nix` and no one has brought it up before.