### PR TITLE
issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATES/package-bug.md
+++ b/.github/ISSUE_TEMPLATES/package-bug.md
@@ -1,0 +1,12 @@
+---
+name: Package Bug Report
+about: Is there a bug in the build of a preexisting package? 
+title: "[package bug] - "
+---
+# Package bug report
+
+- **Package name**:
+- **Package version(s) that had this issue**:
+
+# (Ideally) minimal .nix file to reproduce
+

--- a/.github/ISSUE_TEMPLATES/package-request.md
+++ b/.github/ISSUE_TEMPLATES/package-request.md
@@ -1,0 +1,7 @@
+---
+name: Package Request
+about: Is there a package missing from https://python.on-nix.com/ ?.
+title: "[package request] - <packagename>"
+---
+# Package Request
+

--- a/.github/ISSUE_TEMPLATES/tool-bug.md
+++ b/.github/ISSUE_TEMPLATES/tool-bug.md
@@ -1,0 +1,6 @@
+---
+name: Tool Bug Report
+about: Is there a bug with the overall python-on-nix tool? 
+title: "[bug] - "
+---
+## (Ideally) minimal `.nix` file and desired functionality to reproduce. 


### PR DESCRIPTION
LMK what you think, feel free to push to this branch to reflect however you want the worfklow to be. 

I wasn't able to play with the `labels` feature but we can auto-add labels in issues templates as long as their preexisting. Maybe you could add `package request`, `package bug`, `tool bug` labels? 

I'm not married to the phrase "tool bug", so if you think of something different lmk. 